### PR TITLE
Restore ability to browse all collection items

### DIFF
--- a/collections/show.php
+++ b/collections/show.php
@@ -31,7 +31,7 @@ $totalItems = metadata('collection', 'total_items');
         </div>
         <?php endif; ?>
         <div class="top-bar-right">
-            <?php if ($totalItems > 0): ?>        
+            <?php if ($totalItems > 0): ?>
             <?php
             $sortLinks[__('Title')] = 'Dublin Core,Title';
             $sortLinks[__('Creator')] = 'Dublin Core,Creator';
@@ -39,8 +39,8 @@ $totalItems = metadata('collection', 'total_items');
             ?>
             <div id="sort-links">
                 <span class="sort-label"><?php echo __('Sort by: '); ?></span><?php echo browse_sort_links($sortLinks); ?>
-            </div>
-            
+            </div>       
+                 
             <?php endif; ?>
         </div>
     </div>
@@ -65,6 +65,11 @@ $totalItems = metadata('collection', 'total_items');
     </li>
     <?php endforeach; ?>
     </ul>
+    <?php if ($totalItems > 0): ?>
+        <div id="item-list-footer">
+            <?php echo link_to_items_browse(__(plural('View item', 'View all %s items', $totalItems), $totalItems), array('collection' => metadata('collection', 'id')), array('class' => 'view-items-link')); ?>
+        </div>
+    <?php endif; ?>
 </div><!-- end collection-items -->
 
 <?php fire_plugin_hook('public_collections_show', array('view' => $this, 'collection' => $collection)); ?>


### PR DESCRIPTION
Default Omeka installs show a _browse all items_ link at the bottom of a collection's dedicated page. The Foundation theme overrides Omeka's original ``show.php`` page, and so far, the link to browse all collection items was not part of the new view. This commit adds it back to restore this feature.